### PR TITLE
Added ParrelSync v1.5.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "Assets/Mirror"]
 	path = Assets/Mirror
 	url = https://github.com/vis2k/Mirror/
+[submodule "Assets/ParrelSync"]
+	path = Assets/ParrelSync
+	url = https://github.com/VeriorPies/ParrelSync


### PR DESCRIPTION
From [ParrelSync repository](https://github.com/VeriorPies/ParrelSync) :
> ParrelSync is a Unity editor extension that allows users to test multiplayer gameplay without building the project by having another Unity editor window opened and mirror the changes from the original project.