### PR TITLE
Multiple Character Controller Tweaks

### DIFF
--- a/Assets/Scripts/CameraController.cs
+++ b/Assets/Scripts/CameraController.cs
@@ -20,7 +20,7 @@ public class CameraController : MonoBehaviour
 
     void Start()
     {
-
+        Cursor.lockState = CursorLockMode.Locked;
     }
 
     void Update()
@@ -34,7 +34,7 @@ public class CameraController : MonoBehaviour
     void MovementCamera()
     {
 
-        if (Input.GetMouseButton(1))
+        //if (Input.GetMouseButton(1))
         {
             yAxisWorld += Input.GetAxis("Mouse X") * 5f;
             pitch -= Input.GetAxis("Mouse Y");
@@ -50,5 +50,10 @@ public class CameraController : MonoBehaviour
         {
             transform.position = player.transform.position - transform.forward * distToTarget;
         }
+    }
+
+    public float GetYAxisWorld()
+    {
+        return yAxisWorld;
     }
 }

--- a/Assets/Scripts/CharacterController/CIF/CharacterInputFeed.cs
+++ b/Assets/Scripts/CharacterController/CIF/CharacterInputFeed.cs
@@ -14,13 +14,15 @@ public abstract class CharacterInputFeed
 
     public abstract bool IsWalkingBackwards();
 
-    public abstract bool IsTurningLeft();
+    public abstract bool IsStrafingLeft();
 
-    public abstract bool IsTurningRight();
+    public abstract bool IsStrafingRight();
 
     public abstract bool IsSprinting();
 
     public abstract bool IsCrouching();
 
     public abstract bool AttemptsAttack();
+
+    public abstract float GetLookDirection();
 }

--- a/Assets/Scripts/CharacterController/CIF/EmptyCIF.cs
+++ b/Assets/Scripts/CharacterController/CIF/EmptyCIF.cs
@@ -15,12 +15,12 @@ public class EmptyCIF : CharacterInputFeed
         return false;
     }
 
-    public override bool IsTurningLeft()
+    public override bool IsStrafingLeft()
     {
         return false;
     }
 
-    public override bool IsTurningRight()
+    public override bool IsStrafingRight()
     {
         return false;
     }
@@ -53,5 +53,10 @@ public class EmptyCIF : CharacterInputFeed
     public override bool AttemptsAttack()
     {
         return false;
+    }
+
+    public override float GetLookDirection()
+    {
+        return 0f;
     }
 }

--- a/Assets/Scripts/CharacterController/CIF/LocalKeyboardCIF.cs
+++ b/Assets/Scripts/CharacterController/CIF/LocalKeyboardCIF.cs
@@ -4,6 +4,18 @@ using UnityEngine;
 
 public class LocalKeyboardCIF : CharacterInputFeed
 {
+    private CameraController camController;
+
+    public LocalKeyboardCIF(CameraController camController)
+    {
+        this.camController = camController;
+    }
+
+    public override float GetLookDirection()
+    {
+        return camController.GetYAxisWorld();
+    }
+
     public override bool IsCrouching()
     {
         if (Input.GetKey(KeyCode.LeftControl))
@@ -22,7 +34,7 @@ public class LocalKeyboardCIF : CharacterInputFeed
         return false;
     }
 
-    public override bool IsTurningLeft()
+    public override bool IsStrafingLeft()
     {
         if (Input.GetKey(KeyCode.A))
         {
@@ -31,7 +43,7 @@ public class LocalKeyboardCIF : CharacterInputFeed
         return false;
     }
 
-    public override bool IsTurningRight()
+    public override bool IsStrafingRight()
     {
         if (Input.GetKey(KeyCode.D))
         {

--- a/Assets/Scripts/CharacterController/CharacterController.cs
+++ b/Assets/Scripts/CharacterController/CharacterController.cs
@@ -18,13 +18,19 @@ public class CharacterController : NetworkBehaviour
     private ProceduralAnimation<HumanoidRigidRig> idleAnim;
     private ProceduralAnimation<HumanoidRigidRig> attackAnim;
 
+    
+
     void Start()
     {
+        CameraController camController;
+
+        camController = Camera.main.GetComponent<CameraController>();
+
         rb = GetComponent<Rigidbody>();
 
         if (isLocalPlayer)
         {
-            cif = new LocalKeyboardCIF();
+            cif = new LocalKeyboardCIF(camController);
         } else
         {
             cif = new EmptyCIF();
@@ -41,7 +47,7 @@ public class CharacterController : NetworkBehaviour
 
         movementController = new MovementController(rb, cif);
 
-        Camera.main.GetComponent<CameraController>().SetCameraTarget(transform);
+        camController.SetCameraTarget(transform);
     }
 
     private void Update()

--- a/Assets/Scripts/CharacterController/MovementController.cs
+++ b/Assets/Scripts/CharacterController/MovementController.cs
@@ -15,6 +15,8 @@ public class MovementController
     {
         this.rb = rb;
         this.cif = cif;
+
+        rb.SetMaxAngularVelocity(0);
     }
 
     public void Step(float delta)
@@ -32,30 +34,52 @@ public class MovementController
 
         if (cif.StartJump())
         {
-            rb.AddForce(Vector3.up * 3f, ForceMode.Impulse);
+            rb.AddForce(Vector3.up * 5f, ForceMode.Impulse);
             // animationController.SwitchTo(ProcAnims.Jump);
         }
 
         if (cif.IsWalking())
         {
+            
+            /// TODO : replace rb.transform.rotation assignment with rb.MoveRotation()
+            /// ( You have to compute the difference quaternion )
+            Quaternion t = Quaternion.Euler(new Vector3(0f, cif.GetLookDirection(), 0f));
+            rb.transform.rotation = t;
+
+
             rb.MovePosition(rb.position + rb.rotation * Vector3.forward * shiftMultiplier * delta * forwardSpeed);
         }
 
         if (cif.IsWalkingBackwards())
         {
+            /// TODO : replace rb.transform.rotation assignment with rb.MoveRotation()
+            /// ( You have to compute the difference quaternion )
+            Quaternion t = Quaternion.Euler(new Vector3(0f, cif.GetLookDirection(), 0f));
+            rb.transform.rotation = t;
+
             rb.MovePosition(rb.position - rb.rotation * Vector3.forward * delta * forwardSpeed);
         }
 
-        if (cif.IsTurningRight())
+        if (cif.IsStrafingRight())
         {
+            /// TODO : replace rb.transform.rotation assignment with rb.MoveRotation()
+            /// ( You have to compute the difference quaternion )
+            Quaternion t = Quaternion.Euler(new Vector3(0f, cif.GetLookDirection(), 0f));
+            rb.transform.rotation = t;
+
             /*Quaternion deltaRotation = Quaternion.Euler(m_EulerAngleVelocity * delta);
             rb.MoveRotation(rb.rotation * deltaRotation);*/
 
             rb.MovePosition(rb.position + rb.rotation * Vector3.right * delta * forwardSpeed/2);
         }
 
-        if (cif.IsTurningLeft())
+        if (cif.IsStrafingLeft())
         {
+            /// TODO : replace rb.transform.rotation assignment with rb.MoveRotation()
+            /// ( You have to compute the difference quaternion )
+            Quaternion t = Quaternion.Euler(new Vector3(0f, cif.GetLookDirection(), 0f));
+            rb.transform.rotation = t;
+
             /*Quaternion deltaRotation = Quaternion.Euler(-m_EulerAngleVelocity * delta);
             rb.MoveRotation(rb.rotation * deltaRotation);*/
 


### PR DESCRIPTION
# Changes
+ Set the max angular velocity of the character rigidbody to 0 so it doesn't spin after navigating on slopes, etc.
+ Locked cursor.
+ The camera position now feeds the Y-axis rotation into the CIF. ( `cif.GetLookDirection()` )
+ The character now walks in the direction of the camera. ( 'Forward' now means the direction the camera is looking towards ).
+ Renamed two CIF functions ( from Turning to Strafing ) because the movement controller logic changed since they were first named.
+ Boosted jump impulse multiplier.

# To be fixed
+ The movement controller now rotates the rigidbody's **transform** instead of using `rb.MoveRotation(...)` to rotate the player character. The latter should be used though in an ideal setup. This is left for a later fix as someone has to figure out the quaternions for it.

# Preview
![image](https://user-images.githubusercontent.com/17801706/126880023-9eea937b-03e7-43aa-aeaf-bf77a8be1849.png)
