### PR TITLE
Initial Humanoid Pose

### DIFF
--- a/Assets/Scripts/CharacterController/CharacterController.cs
+++ b/Assets/Scripts/CharacterController/CharacterController.cs
@@ -18,8 +18,6 @@ public class CharacterController : NetworkBehaviour
     private ProceduralAnimation<HumanoidRigidRig> idleAnim;
     private ProceduralAnimation<HumanoidRigidRig> attackAnim;
 
-    
-
     void Start()
     {
         CameraController camController;
@@ -32,6 +30,7 @@ public class CharacterController : NetworkBehaviour
         {
             cif = new LocalKeyboardCIF(camController);
             camController.SetCameraTarget(transform);
+            HumanoidRigInitialPose.SetupInstance(rigParts);
         } else
         {
             cif = GetComponent<CIFSync>();// new NetworkedCIF();

--- a/Assets/Scripts/CharacterController/Humanoid/HumanIdle.cs
+++ b/Assets/Scripts/CharacterController/Humanoid/HumanIdle.cs
@@ -7,13 +7,6 @@ public class HumanIdle : ProceduralAnimation<HumanoidRigidRig>
     private HumanoidRigidRig rig;
     private CharacterInputFeed cif;
 
-    private Vector3 initialHeadPos;
-    private Vector3 initialChestPos;
-    private Vector3 initialBeltPos;
-    private Vector3 initialPantsPos;
-    private Vector3 initialLeftHandPos;
-    private Vector3 initialRightHandPos;
-
     private float t = 0;
 
     public HumanIdle(HumanoidRigidRig rig, CharacterInputFeed cif)
@@ -26,16 +19,6 @@ public class HumanIdle : ProceduralAnimation<HumanoidRigidRig>
 
     public override void OnAnimationStart() 
     {
-        // TODO : Create an initial pose transform list that is globally-accessible 
-        // ( So you can create mathematically-defined animations
-        // based on the difference between your desired pose and the initial pose ).
-        initialHeadPos = rig.head.localPosition;
-        initialChestPos = rig.chest.localPosition;
-        initialBeltPos = rig.belt.localPosition;
-        initialPantsPos = rig.pants.localPosition;
-        initialLeftHandPos = rig.leftHand.localPosition;
-        initialRightHandPos = rig.rightHand.localPosition;
-
         t = 0;
     }
 
@@ -49,37 +32,37 @@ public class HumanIdle : ProceduralAnimation<HumanoidRigidRig>
 
         rig.head.localPosition = new Vector3(
         rig.head.localPosition.x,
-        Yrot1 + initialHeadPos.y,
+        Yrot1 + HumanoidRigInitialPose.instance.head.y,
         rig.head.localPosition.z
         );
 
         rig.chest.localPosition = new Vector3(
         rig.chest.localPosition.x,
-        Yrot + initialChestPos.y,
+        Yrot + HumanoidRigInitialPose.instance.chest.y,
         rig.chest.localPosition.z
         );
 
         rig.belt.localPosition = new Vector3(
         rig.belt.localPosition.x,
-        Yrot + initialBeltPos.y,
+        Yrot + HumanoidRigInitialPose.instance.belt.y,
         rig.belt.localPosition.z
         );
 
         rig.pants.localPosition = new Vector3(
         rig.pants.localPosition.x,
-        Yrot + initialPantsPos.y,
+        Yrot + HumanoidRigInitialPose.instance.pants.y,
         rig.pants.localPosition.z
         );
 
         rig.leftHand.localPosition = new Vector3(
         rig.leftHand.localPosition.x,
-        Yrot + initialLeftHandPos.y,
+        Yrot + HumanoidRigInitialPose.instance.leftHand.y,
         rig.leftHand.localPosition.z
         );
 
         rig.rightHand.localPosition = new Vector3(
         rig.rightHand.localPosition.x,
-        Yrot + initialRightHandPos.y,
+        Yrot + HumanoidRigInitialPose.instance.rightHand.y,
         rig.rightHand.localPosition.z
         );
     }

--- a/Assets/Scripts/CharacterController/Humanoid/HumanoidRigidRig.cs
+++ b/Assets/Scripts/CharacterController/Humanoid/HumanoidRigidRig.cs
@@ -21,3 +21,39 @@ public class HumanoidRigidRig : IEntityRig
     public Transform leftShoulder;
     public Transform rightShoulder;
 }
+
+public class HumanoidRigInitialPose
+{
+    public static HumanoidRigInitialPose instance = new HumanoidRigInitialPose();
+
+    public static void SetupInstance(HumanoidRigidRig rig)
+    {
+        instance.head = rig.head.localPosition;
+        instance.chest = rig.chest.localPosition;
+        instance.belt = rig.belt.localPosition;
+        instance.pants = rig.pants.localPosition;
+
+        instance.leftFoot = rig.leftFoot.localPosition;
+        instance.rightFoot = rig.rightFoot.localPosition;
+
+        instance.leftHand = rig.leftHand.localPosition;
+        instance.rightHand = rig.rightHand.localPosition;
+
+        instance.leftShoulder = rig.leftShoulder.localPosition;
+        instance.rightShoulder = rig.rightShoulder.localPosition;
+    }
+
+    public Vector3 head;
+    public Vector3 chest;
+    public Vector3 belt;
+    public Vector3 pants;
+
+    public Vector3 leftFoot;
+    public Vector3 rightFoot;
+
+    public Vector3 leftHand;
+    public Vector3 rightHand;
+
+    public Vector3 leftShoulder;
+    public Vector3 rightShoulder;
+}


### PR DESCRIPTION
# Changes
+ Removed the `HumanIdle` Vector3 items that represent the initial pose of the rig ( when the animation starts )
+ Created a `HumanoidRigInitialPose` class to store the Vector3 part of all rig transforms.
+ The initial pose is set when the first player spawns ( ~ `CharacterController.cs` ~ Start function ).
+ BUGFIX: No more floating heads due to idle animation switching from something else.
