### PR TITLE
Solved bug related to syncing the (default) sword over network

### DIFF
--- a/Assets/Prefabs/Character.prefab
+++ b/Assets/Prefabs/Character.prefab
@@ -560,7 +560,8 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 3909408325649396769}
   m_Father: {fileID: 6727609259259669116}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1336,4 +1337,70 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 4595604111329244729, guid: ee57ca9bbbc19584e8f1665ede3c54c5, type: 3}
   m_PrefabInstance: {fileID: 997444611337770990}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5852302119770065386
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 308564722792744709}
+    m_Modifications:
+    - target: {fileID: 7455304483969465803, guid: 5b16aea52c4b77d4e8ed94bcd488e19b, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7455304483969465803, guid: 5b16aea52c4b77d4e8ed94bcd488e19b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7455304483969465803, guid: 5b16aea52c4b77d4e8ed94bcd488e19b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7455304483969465803, guid: 5b16aea52c4b77d4e8ed94bcd488e19b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7455304483969465803, guid: 5b16aea52c4b77d4e8ed94bcd488e19b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7455304483969465803, guid: 5b16aea52c4b77d4e8ed94bcd488e19b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7455304483969465803, guid: 5b16aea52c4b77d4e8ed94bcd488e19b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7455304483969465803, guid: 5b16aea52c4b77d4e8ed94bcd488e19b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7455304483969465803, guid: 5b16aea52c4b77d4e8ed94bcd488e19b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7455304483969465803, guid: 5b16aea52c4b77d4e8ed94bcd488e19b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7455304483969465803, guid: 5b16aea52c4b77d4e8ed94bcd488e19b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7799494863423022961, guid: 5b16aea52c4b77d4e8ed94bcd488e19b, type: 3}
+      propertyPath: m_Name
+      value: sword
+      objectReference: {fileID: 0}
+    - target: {fileID: 7799494863423022961, guid: 5b16aea52c4b77d4e8ed94bcd488e19b, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5b16aea52c4b77d4e8ed94bcd488e19b, type: 3}
+--- !u!4 &3909408325649396769 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7455304483969465803, guid: 5b16aea52c4b77d4e8ed94bcd488e19b, type: 3}
+  m_PrefabInstance: {fileID: 5852302119770065386}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Scripts/CharacterController/CharacterOutfitSync.cs
+++ b/Assets/Scripts/CharacterController/CharacterOutfitSync.cs
@@ -7,9 +7,26 @@ public class CharacterOutfitSync : NetworkBehaviour
 {
     private HumanoidRigidRig rigParts;
 
-    public void Awake()
+    private void Awake()
     {
         rigParts = GetComponent<CharacterController>().rigParts;
+    }
+
+    private void Update()
+    {
+        if (!isLocalPlayer)
+        {
+            return;
+        }
+
+        if (isServer)
+        {
+            RpcChooseDefault();
+        }
+        else
+        {
+            CmdChooseDefault();
+        }
     }
 
     public void LocalInit()
@@ -94,15 +111,14 @@ public class CharacterOutfitSync : NetworkBehaviour
     [SyncVar(hook = nameof(SetClass))]
     int classIndex = 0;
 
-    void SetClass(int oldClass, int newClass)
+    private void SetClass(int oldClass, int newClass)
     {
         ChangeWeaponTo(newClass);
     }
 
-    public void ChangeWeaponTo(int weapon)
+    private void ChangeWeaponTo(int weapon)
     {
         Transform grip = rigParts.rightHand.Find("weapon-grip");
-
 
         for (int i = grip.childCount - 1; i >= 0; i--)
         {
@@ -126,6 +142,34 @@ public class CharacterOutfitSync : NetworkBehaviour
     public void CmdSetWeapon(int _classIndex)
     {
         this.classIndex = _classIndex;
+    }
+
+    public void SetSword()
+    {
+        Transform grip = rigParts.rightHand.Find("weapon-grip");
+
+        if (classIndex == 0)
+        {
+            grip.GetChild(classIndex).gameObject.SetActive(true);
+        }
+    }
+
+    [Command]
+    private void CmdChooseDefault()
+    {
+        SetSword();
+        RpcChooseDefault();
+    }
+
+    [ClientRpc]
+    private void RpcChooseDefault()
+    {
+        if (isLocalPlayer)
+        {
+            return;
+        }
+            
+        SetSword();
     }
 
     public int GetClassIndex()


### PR DESCRIPTION
# Changes
+ Added a sword prefab on Character and disabled this component 
+ Synced `.SetActive()` over network in order to enable the component for all the clients in case the sword was chosen

# TODO (not so important)
+ Add a warning prompt in case none of the classes were chosen
